### PR TITLE
Default to highest precision timer in timecall

### DIFF
--- a/profilehooks.py
+++ b/profilehooks.py
@@ -143,7 +143,7 @@ except ImportError:
     cProfile = None
 
 # For timecall
-import time
+import timeit
 
 
 # registry of available profilers
@@ -714,7 +714,7 @@ def timecall(fn=None, immediate=True, timer=None):
 
         @timecall(immediate=False)
 
-    You can also choose a timing method other than the default ``time.time()``,
+    You can also choose a timing method other than the default ``timeit.default_timer()``,
     e.g.:
 
         @timecall(timer=time.clock)
@@ -726,7 +726,7 @@ def timecall(fn=None, immediate=True, timer=None):
         return decorator
     # @timecall syntax -- we are a decorator.
     if timer is None:
-        timer = time.time
+        timer = timeit.default_timer
     fp = FuncTimer(fn, immediate=immediate, timer=timer)
     # We cannot return fp or fp.__call__ directly as that would break method
     # definitions, instead we need to return a plain function.

--- a/test_profilehooks.py
+++ b/test_profilehooks.py
@@ -14,7 +14,6 @@ import unittest
 import inspect
 import atexit
 import textwrap
-import time
 
 try:
     from cStringIO import StringIO
@@ -477,15 +476,12 @@ def setUp(test):
     sys.stderr = stderr_wrapper
     atexit.register = _register_exitfunc
     del _exitfuncs[:]
-    test.real_time = time.time
-    time.time = lambda: 1411735756
 
 
 def tearDown(test):
     sys.stderr = test.real_stderr
     atexit.register = test.real_register
     del _exitfuncs[:]
-    time.time = test.real_time
 
 
 def additional_tests():

--- a/test_profilehooks.py
+++ b/test_profilehooks.py
@@ -14,6 +14,7 @@ import unittest
 import inspect
 import atexit
 import textwrap
+import timeit
 
 try:
     from cStringIO import StringIO
@@ -476,12 +477,15 @@ def setUp(test):
     sys.stderr = stderr_wrapper
     atexit.register = _register_exitfunc
     del _exitfuncs[:]
+    test.real_time = timeit.default_timer
+    timeit.default_timer = lambda: 1411735756
 
 
 def tearDown(test):
     sys.stderr = test.real_stderr
     atexit.register = test.real_register
     del _exitfuncs[:]
+    timeit.default_timer = test.real_time
 
 
 def additional_tests():


### PR DESCRIPTION
This PR changes the default timer used in `timecall`  from `time.time()` to `timeit.default_timer()`.  By using `timeit.default_timer()`, you are assured the highest precision clock is always used.

`timeit.default_timer()` will choose which clock gets used depending on the platform and version of Python you are running:
 * Python < 3.3:
   * `time.time()` is used on Unix-like systems
   * `time.clock()` is used on Windows.
 * Python >= 3.3:
   * `time.performance_counter()` is always used on all platforms

Note: This PR also removes some unused code in `test_profilehooks.py` that was related to the time module.