### PR TITLE
Add support for sending output to something besides stdout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.11.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Added the ability to pass a text-mode file descriptor to the `stdout` kwarg
+  of the `profile` decorator / `FuncProfiler` constructor for capturing
+  output.
 
 
 1.11.2 (2020-03-03)

--- a/profilehooks.py
+++ b/profilehooks.py
@@ -98,7 +98,6 @@ import atexit
 
 import functools
 import inspect
-import io
 import logging
 import os
 import re
@@ -182,10 +181,7 @@ def _identify(fn):
 
 
 def _is_file_like(o):
-    if sys.version_info[0] >= 3:
-        return isinstance(o, io.IOBase)
-    else:
-        return hasattr(o, 'write')
+    return hasattr(o, 'write')
 
 
 def profile(fn=None, skip=0, filename=None, immediate=False, dirs=False,

--- a/test_profilehooks.py
+++ b/test_profilehooks.py
@@ -277,6 +277,32 @@ def doctest_profile_with_args():
     """
 
 
+def doctest_profile_with_stdout_redirect():
+    """Test for profile.
+
+        >>> from tempfile import TemporaryFile
+        >>> fp = TemporaryFile(mode="w+")
+
+
+        >>> @profilehooks.profile(stdout=fp)
+        ... def sample_fn(x, y, z):
+        ...     return x + y * z
+
+
+        >>> sample_fn(3, 2, 1)
+        5
+        >>> run_exitfuncs()
+        >>> fp.flush()
+        >>> fp.seek(0)
+        0
+        >>> print(fp.read())
+        <BLANKLINE>
+        *** PROFILER RESULTS ***
+        sample_fn (<doctest test_profilehooks.doctest_profile_with_stdout_redirect[2]>:1)
+        ...
+    """
+
+
 def doctest_profile_with_bad_args():
     """Test for profile.
 

--- a/test_profilehooks.py
+++ b/test_profilehooks.py
@@ -293,8 +293,7 @@ def doctest_profile_with_stdout_redirect():
         5
         >>> run_exitfuncs()
         >>> fp.flush()
-        >>> fp.seek(0)
-        0
+        >>> _ = fp.seek(0)
         >>> print(fp.read())
         <BLANKLINE>
         *** PROFILER RESULTS ***


### PR DESCRIPTION
Added versatility to the `stdout` parameter of the profile hook / profile classes.

Specifying a "file-like" object will send all the output of `FuncProfile.print_stats` to that file object instead of `sys.stdout`. Feedback welcome.
